### PR TITLE
fix: use react portals to mount the keyboard component

### DIFF
--- a/dist/components/app.js
+++ b/dist/components/app.js
@@ -9,6 +9,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var React = require('react');
+var ReactDOM = require("react-dom");
 
 var _require = require('../fake-react-native-web'),
     View = _require.View;
@@ -95,13 +96,13 @@ var App = function (_React$Component) {
                         }
                     })
                 ),
-                React.createElement(Keypad, {
+                ReactDOM.createPortal(React.createElement(Keypad, {
                     onElementMounted: function onElementMounted(node) {
                         if (node && !_this3.state.keypadElement) {
                             _this3.setState({ keypadElement: node });
                         }
                     }
-                })
+                }), document.body)
             );
         }
     }]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "math-input-web-support",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "",
   "main": "dist/index.js",
   "files": ["dist"],

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactDOM = require("react-dom");
 
 const { View } = require('../fake-react-native-web');
 const { components } = require('../index');
@@ -54,13 +55,16 @@ class App extends React.Component {
                     ref={(element) => this.keypadInput = element}
                 />
             </div>
-            <Keypad
-                onElementMounted={node => {
-                    if (node && !this.state.keypadElement) {
-                        this.setState({keypadElement: node});
-                    }
+            {ReactDOM.createPortal(
+              <Keypad
+                onElementMounted={(node) => {
+                  if (node && !this.state.keypadElement) {
+                    this.setState({ keypadElement: node });
+                  }
                 }}
-            />
+              />,
+              document.body
+            )}
         </View>;
     }
 }


### PR DESCRIPTION
This PR changes the Keyboard component mounting to use react portals, avoiding the overlay issue